### PR TITLE
feat(pdf解析块坐标溯源): 对mineru的解析结果，增加pdf解析块坐标溯源功能

### DIFF
--- a/management/server/services/knowledgebases/service.py
+++ b/management/server/services/knowledgebases/service.py
@@ -600,7 +600,6 @@ class KnowledgebaseService:
                     conn.commit()  # 先提交更新操作
                 except Exception as e:
                     print(f"[WARNING] 更新知识库文档数量失败，但文档已添加: {str(e)}")
-                    # 这里不抛出异常，因为文档已经添加成功
             
             cursor.close()
             conn.close()
@@ -663,7 +662,7 @@ class KnowledgebaseService:
 
     @classmethod
     def parse_document(cls, doc_id):
-        """解析文档（同步版本，调用后台解析逻辑）"""
+        """解析文档（调用解析逻辑）"""
         conn = None
         cursor = None
         try:
@@ -717,7 +716,6 @@ class KnowledgebaseService:
                  _update_document_progress(doc_id, status='1', run='0', message=f"解析失败: {str(e)}")
             except Exception as update_err:
                  print(f"更新文档失败状态时出错 (Doc ID: {doc_id}): {str(update_err)}")
-            # 向上层抛出异常或返回错误信息
             # raise Exception(f"文档解析失败: {str(e)}")
             return {"success": False, "error": f"文档解析失败: {str(e)}"}
 


### PR DESCRIPTION
- 新增 `get_text_from_block` 函数，用于从 `preproc_blocks` 中提取文本内容
- 在 `perform_parse` 中增加对 `middle_json_content` 的解析，提取块信息并匹配到文本块
- 更新 ES 文档结构，增加 `page_num_int` 和 `position_int` 字段，记录块在文档中的位置

### 选择一个类型

- [ ] Bug修复(Bug Fix) 
- [ ] 新功能(New Feature)
- [ ] 文档更新(Documentation Update)
- [ ] 重构(Refactoring)
- [ ] 性能优化(Performance Improvement)
- [ ] 其他(Other)
