### PR TITLE
refactor(api): 优化图片插入的 Markdown 格式，增加最大宽度限制

### DIFF
--- a/api/db/services/dialog_service.py
+++ b/api/db/services/dialog_service.py
@@ -270,8 +270,8 @@ def chat(dialog, messages, stream=True, **kwargs):
                 processed_image_urls.add(img_url)
                 inserted_images[idx] = img_url
 
-                # 插入图片，不加任何括号包裹引用标记
-                return f"{match.group(0)}\n\n![img_url]({img_url})"
+                # 插入图片，并限制最大宽度
+                return f'{match.group(0)}\n\n<img src="{img_url}" alt="{img_url}" style="max-width:800px;">'
 
             # 用正则替换插图
             answer = re.sub(r"##(\d+)\$\$", insert_image_markdown, answer)

--- a/api/db/services/write_service.py
+++ b/api/db/services/write_service.py
@@ -92,7 +92,7 @@ def write_dialog(question, kb_ids, tenant_id, similarity_threshold, keyword_simi
 
         if img_url not in image_urls:
             image_urls.add(img_url)
-            image_markdowns.append(f"\n![{img_url}]({img_url})")
+            image_markdowns.append(f'\n<img src="{img_url}" alt="{img_url}" style="max-width:500px; display:block; margin:auto;">')
 
     if image_markdowns:
         final_answer += "".join(image_markdowns)


### PR DESCRIPTION
- 在 dialog_service 和 write_service 中更新了图片插入的 Markdown 格式
- 添加了图片最大宽度限制，提高展示效果
- 在 write_service 中增加了图片居中显示的样式

### 选择一个类型

- [ ] Bug修复(Bug Fix) 
- [ ] 新功能(New Feature)
- [ ] 文档更新(Documentation Update)
- [x] 重构(Refactoring)
- [ ] 性能优化(Performance Improvement)
- [ ] 其他(Other)
