### PR TITLE
使知识库的embedding可选，修改文档解析时获取embedding的逻辑为从知识库的embd_id获取

### DIFF
--- a/management/server/routes/knowledgebases/routes.py
+++ b/management/server/routes/knowledgebases/routes.py
@@ -284,3 +284,24 @@ def get_sequential_batch_parse_progress_route(kb_id):
         print(f"获取顺序批量解析进度路由处理失败 (KB ID: {kb_id}): {str(e)}")
         traceback.print_exc()
         return error_response(f"获取进度失败: {str(e)}", code=500)
+    
+@knowledgebase_bp.route('/embedding_models/<string:kb_id>', methods=['GET'])
+def get_tenant_embedding_models(kb_id):
+    """获取租户的嵌入模型配置"""
+    try:
+        # 调用服务函数获取嵌入模型配置
+        result = KnowledgebaseService.get_tenant_embedding(kb_id)
+        return success_response(data=result)
+    except Exception as e:
+        return error_response(f"获取租户嵌入模型配置失败: {str(e)}", code=500)
+    
+@knowledgebase_bp.route('/embedding_config', methods=['GET'])
+def get_knowledgebase_embedding_config():
+    """获取知识库的嵌入模型配置"""
+    try:
+        kb_id= request.args.get('kb_id', '')
+        # 调用服务函数获取嵌入模型配置
+        result = KnowledgebaseService.get_kb_embedding_config(kb_id)
+        return success_response(data=result)
+    except Exception as e:
+        return error_response(f"获取知识库嵌入模型配置失败: {str(e)}", code=500)

--- a/management/web/src/common/apis/kbs/knowledgebase.ts
+++ b/management/web/src/common/apis/kbs/knowledgebase.ts
@@ -59,6 +59,7 @@ export function updateKnowledgeBaseApi(id: string, data: {
   language?: string
   permission?: string
   avatar?: string
+  embd_id?: string
 }) {
   return request({
     url: `/api/v1/knowledgebases/${id}`,
@@ -96,11 +97,12 @@ export function addDocumentToKnowledgeBaseApi(data: {
   })
 }
 
-// 获取系统 Embedding 配置
-export function getSystemEmbeddingConfigApi() {
+// 获取知识库 Embedding 配置
+export function getKnowledgeBaseEmbeddingConfigApi(params:{kb_id: string}) {
   return request({
-    url: "/api/v1/knowledgebases/system_embedding_config", // 确认 API 路径前缀是否正确
-    method: "get"
+    url: "/api/v1/knowledgebases/embedding_config", // 确认 API 路径前缀是否正确
+    method: "get",
+    params
   })
 }
 
@@ -114,5 +116,13 @@ export function setSystemEmbeddingConfigApi(data: {
     url: "/api/v1/knowledgebases/system_embedding_config", // 确认 API 路径前缀是否正确
     method: "post",
     data
+  })
+}
+
+// 根据知识库id获取租户的 Embedding 模型列表
+export function loadingEmbeddingModelsApi(params:{kb_id: string}) {
+  return request({
+    url: `/api/v1/knowledgebases/embedding_models/${params.kb_id}`,
+    method: "get",
   })
 }


### PR DESCRIPTION
使知识库使用的embedding模型和创建者显示
在知识库的修改处增加embedding模型的选项，同时在测试连接处改为根据知识库的配置测试连接
文档解析时获取embedding的逻辑改为根据知识库的embd_id获取embedding配置

但暂不支持1024维度以外的嵌入模型