### PR TITLE
build(docker): 更新 MinIO 镜像版本

### DIFF
--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -61,7 +61,7 @@ services:
     restart: on-failure
 
   minio:
-    image: quay.io/minio/minio:RELEASE.2023-12-20T01-00-02Z
+    image: quay.io/minio/minio:RELEASE.2025-06-13T11-33-47Z
     container_name: ragflow-minio
     command: server --console-address ":9001" /data
     ports:


### PR DESCRIPTION
- 将 MinIO 镜像版本从 RELEASE.2023-12-20T01-00-02Z 更新到 RELEASE.2025-06-13T11-33-47Z

### 选择一个类型

- [ ] Bug修复(Bug Fix) 
- [ ] 新功能(New Feature)
- [ ] 文档更新(Documentation Update)
- [ ] 重构(Refactoring)
- [ ] 性能优化(Performance Improvement)
- [x] 其他(Other)
