### PR TITLE
feat:新增团队负责人权限页面，将知识库管理功能归属团队管理员(#235)

### DIFF
--- a/management/server/services/auth/__init__.py
+++ b/management/server/services/auth/__init__.py
@@ -1,0 +1,1 @@
+from .auth_utils import get_current_user_from_token, is_admin, is_team_owner

--- a/management/server/services/auth/auth_utils.py
+++ b/management/server/services/auth/auth_utils.py
@@ -1,0 +1,47 @@
+import os
+import jwt
+from flask import request
+
+JWT_SECRET = os.getenv("MANAGEMENT_JWT_SECRET", "your-secret-key")
+
+
+def get_current_user_from_token():
+    """
+    从请求头的JWT token中获取当前用户信息
+    返回: dict 包含 user_id, username, role, tenant_id 或 None
+    """
+    try:
+        auth_header = request.headers.get('Authorization')
+        if not auth_header or not auth_header.startswith('Bearer '):
+            return None
+        
+        token = auth_header.split(' ')[1]
+        
+        try:
+            payload = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
+            return {
+                'user_id': payload.get('user_id'),
+                'username': payload.get('username'),
+                'role': payload.get('role'),
+                'tenant_id': payload.get('tenant_id')
+            }
+        except jwt.ExpiredSignatureError:
+            return None
+        except jwt.InvalidTokenError:
+            return None
+    except Exception:
+        return None
+
+
+def is_admin(user_info):
+    """检查用户是否是超级管理员"""
+    if not user_info:
+        return False
+    return user_info.get('role') == 'admin'
+
+
+def is_team_owner(user_info):
+    """检查用户是否是团队负责人"""
+    if not user_info:
+        return False
+    return user_info.get('role') == 'team_owner'

--- a/management/server/services/files/service.py
+++ b/management/server/services/files/service.py
@@ -49,15 +49,17 @@ def filename_type(filename):
     return FileType.OTHER.value
 
 
-def get_files_list(current_page, page_size, name_filter="", sort_by="create_time", sort_order="desc"):
+def get_files_list(current_page, page_size, name_filter="", sort_by="create_time", sort_order="desc", user_id=None):
     """
     获取文件列表
 
     Args:
         current_page: 当前页码
         page_size: 每页大小
-        parent_id: 父文件夹ID
         name_filter: 文件名过滤条件
+        sort_by: 排序字段
+        sort_order: 排序顺序
+        user_id: 用户ID（如果提供，则只返回该用户上传的文件）
 
     Returns:
         tuple: (文件列表, 总数)
@@ -77,6 +79,11 @@ def get_files_list(current_page, page_size, name_filter="", sort_by="create_time
         if name_filter:
             where_clause += " AND f.name LIKE %s"
             params.append(f"%{name_filter}%")
+        
+        # 如果提供了user_id，则只返回该用户上传的文件
+        if user_id:
+            where_clause += " AND f.created_by = %s"
+            params.append(user_id)
 
         # 验证排序字段
         valid_sort_fields = ["name", "size", "type", "create_time", "create_date"]

--- a/management/server/services/teams/service.py
+++ b/management/server/services/teams/service.py
@@ -3,8 +3,11 @@ from datetime import datetime
 from utils import generate_uuid
 from database import DB_CONFIG
 
-def get_teams_with_pagination(current_page, page_size, name='', sort_by="create_time",sort_order="desc"):
-    """查询团队信息，支持分页和条件筛选"""
+def get_teams_with_pagination(current_page, page_size, name='', sort_by="create_time", sort_order="desc", tenant_id=None):
+    """
+    查询团队信息，支持分页和条件筛选
+    tenant_id: 如果提供，则只返回该租户的团队
+    """
     try:
         conn = mysql.connector.connect(**DB_CONFIG)
         cursor = conn.cursor(dictionary=True)
@@ -16,6 +19,11 @@ def get_teams_with_pagination(current_page, page_size, name='', sort_by="create_
         if name:
             where_clauses.append("t.name LIKE %s")
             params.append(f"%{name}%")
+        
+        # 如果提供了tenant_id，则只返回该租户的团队
+        if tenant_id:
+            where_clauses.append("t.id = %s")
+            params.append(tenant_id)
         
         # 组合WHERE子句
         where_sql = "WHERE " + (" AND ".join(where_clauses) if where_clauses else "1=1")

--- a/management/server/utils.py
+++ b/management/server/utils.py
@@ -4,7 +4,7 @@ import uuid
 from Cryptodome.Cipher import PKCS1_v1_5
 from Cryptodome.PublicKey import RSA
 from flask import jsonify
-from werkzeug.security import generate_password_hash
+from werkzeug.security import generate_password_hash, check_password_hash
 
 
 # 生成随机的 UUID 作为 id
@@ -28,6 +28,12 @@ def rsa_psw(password: str) -> str:
 def encrypt_password(raw_password: str) -> str:
     base64_password = base64.b64encode(raw_password.encode()).decode()
     return generate_password_hash(base64_password)
+
+
+# 验证密码
+def verify_password(raw_password: str, hashed_password: str) -> bool:
+    base64_password = base64.b64encode(raw_password.encode()).decode()
+    return check_password_hash(hashed_password, base64_password)
 
 
 # 标准响应格式

--- a/management/web/src/router/index.ts
+++ b/management/web/src/router/index.ts
@@ -45,113 +45,6 @@ export const constantRoutes: RouteRecordRaw[] = [
     meta: {
       hidden: true
     }
-  },
-  {
-    path: "/",
-    component: Layouts,
-    redirect: "/dashboard",
-    children: [
-      {
-        path: "dashboard",
-        component: () => import("@/pages/user-management/index.vue"),
-        name: "UserManagement",
-        meta: {
-          title: "用户管理",
-          svgIcon: "user-management",
-          affix: true
-        }
-      }
-    ]
-  },
-  {
-    path: "/team",
-    component: Layouts,
-    redirect: "/team/index",
-    children: [
-      {
-        path: "index",
-        component: () => import("@/pages/team-management/index.vue"),
-        name: "Team",
-        meta: {
-          title: "团队管理",
-          svgIcon: "team-management",
-          affix: false,
-          keepAlive: true
-        }
-      }
-    ]
-  },
-  {
-    path: "/config",
-    component: Layouts,
-    redirect: "/config/index",
-    children: [
-      {
-        path: "index",
-        component: () => import("@/pages/user-config/index.vue"),
-        name: "UserConfig",
-        meta: {
-          title: "用户配置",
-          svgIcon: "user-config",
-          affix: false,
-          keepAlive: true
-        }
-      }
-    ]
-  },
-  {
-    path: "/file",
-    component: Layouts,
-    redirect: "/file/index",
-    children: [
-      {
-        path: "index",
-        component: () => import("@/pages/file/index.vue"),
-        name: "File",
-        meta: {
-          title: "文件管理",
-          svgIcon: "file",
-          affix: false,
-          keepAlive: true
-        }
-      }
-    ]
-  },
-  {
-    path: "/knowledgebase",
-    component: Layouts,
-    redirect: "/knowledgebase/index",
-    children: [
-      {
-        path: "index",
-        component: () => import("@/pages/knowledgebase/index.vue"),
-        name: "KnowledgeBase",
-        meta: {
-          title: "知识库管理",
-          svgIcon: "kb",
-          affix: false,
-          keepAlive: true
-        }
-      }
-    ]
-  },
-  {
-    path: "/conversation",
-    component: Layouts,
-    redirect: "/conversation/index",
-    children: [
-      {
-        path: "index",
-        component: () => import("@/pages/conversation/index.vue"),
-        name: "conversation",
-        meta: {
-          title: "用户会话管理",
-          svgIcon: "conversation",
-          affix: false,
-          keepAlive: true
-        }
-      }
-    ]
   }
 ]
 
@@ -161,41 +54,153 @@ export const constantRoutes: RouteRecordRaw[] = [
  * @description 必须带有唯一的 Name 属性
  */
 export const dynamicRoutes: RouteRecordRaw[] = [
-  // {
-  //   path: "/permission",
-  //   component: Layouts,
-  //   redirect: "/permission/page-level",
-  //   name: "Permission",
-  //   meta: {
-  //     title: "权限演示",
-  //     elIcon: "Lock",
-  //     // 可以在根路由中设置角色
-  //     roles: ["admin", "editor"],
-  //     alwaysShow: true
-  //   },
-  //   children: [
-  //     {
-  //       path: "page-level",
-  //       component: () => import("@/pages/demo/permission/page-level.vue"),
-  //       name: "PermissionPageLevel",
-  //       meta: {
-  //         title: "页面级",
-  //         // 或者在子路由中设置角色
-  //         roles: ["admin"]
-  //       }
-  //     },
-  //     {
-  //       path: "button-level",
-  //       component: () => import("@/pages/demo/permission/button-level.vue"),
-  //       name: "PermissionButtonLevel",
-  //       meta: {
-  //         title: "按钮级",
-  //         // 如果未设置角色，则表示：该页面不需要权限，但会继承根路由的角色
-  //         roles: undefined
-  //       }
-  //     }
-  //   ]
-  // }
+  {
+    path: "/",
+    component: Layouts,
+    redirect: "/file",
+    name: "Root",
+    meta: {
+      roles: ["admin", "team_owner"]
+    },
+    children: []
+  },
+  {
+    path: "/dashboard",
+    component: Layouts,
+    redirect: "/dashboard/index",
+    name: "Dashboard",
+    meta: {
+      roles: ["admin"]
+    },
+    children: [
+      {
+        path: "index",
+        component: () => import("@/pages/user-management/index.vue"),
+        name: "UserManagement",
+        meta: {
+          title: "用户管理",
+          svgIcon: "user-management",
+          affix: true,
+          roles: ["admin"]
+        }
+      }
+    ]
+  },
+  {
+    path: "/team",
+    component: Layouts,
+    redirect: "/team/index",
+    name: "TeamManagement",
+    meta: {
+      roles: ["admin", "team_owner"]
+    },
+    children: [
+      {
+        path: "index",
+        component: () => import("@/pages/team-management/index.vue"),
+        name: "Team",
+        meta: {
+          title: "团队管理",
+          svgIcon: "team-management",
+          affix: false,
+          keepAlive: true,
+          roles: ["admin", "team_owner"]
+        }
+      }
+    ]
+  },
+  {
+    path: "/config",
+    component: Layouts,
+    redirect: "/config/index",
+    name: "ConfigManagement",
+    meta: {
+      roles: ["admin"]
+    },
+    children: [
+      {
+        path: "index",
+        component: () => import("@/pages/user-config/index.vue"),
+        name: "UserConfig",
+        meta: {
+          title: "用户配置",
+          svgIcon: "user-config",
+          affix: false,
+          keepAlive: true,
+          roles: ["admin"]
+        }
+      }
+    ]
+  },
+  {
+    path: "/file",
+    component: Layouts,
+    redirect: "/file/index",
+    name: "FileManagement",
+    meta: {
+      roles: ["admin", "team_owner"]
+    },
+    children: [
+      {
+        path: "index",
+        component: () => import("@/pages/file/index.vue"),
+        name: "File",
+        meta: {
+          title: "文件管理",
+          svgIcon: "file",
+          affix: false,
+          keepAlive: true,
+          roles: ["admin", "team_owner"]
+        }
+      }
+    ]
+  },
+  {
+    path: "/knowledgebase",
+    component: Layouts,
+    redirect: "/knowledgebase/index",
+    name: "KnowledgeBaseManagement",
+    meta: {
+      roles: ["admin", "team_owner"]
+    },
+    children: [
+      {
+        path: "index",
+        component: () => import("@/pages/knowledgebase/index.vue"),
+        name: "KnowledgeBase",
+        meta: {
+          title: "知识库管理",
+          svgIcon: "kb",
+          affix: false,
+          keepAlive: true,
+          roles: ["admin", "team_owner"]
+        }
+      }
+    ]
+  },
+  {
+    path: "/conversation",
+    component: Layouts,
+    redirect: "/conversation/index",
+    name: "ConversationManagement",
+    meta: {
+      roles: ["admin"]
+    },
+    children: [
+      {
+        path: "index",
+        component: () => import("@/pages/conversation/index.vue"),
+        name: "Conversation",
+        meta: {
+          title: "用户会话管理",
+          svgIcon: "conversation",
+          affix: false,
+          keepAlive: true,
+          roles: ["admin"]
+        }
+      }
+    ]
+  }
 ]
 
 /** 路由实例 */


### PR DESCRIPTION


后台管理系统的**多角色权限控制**，主要特点：

1. **角色分离**: 超级管理员拥有全局权限，团队负责人仅管理其团队资源
2. **数据隔离**: 团队负责人只能查看和操作其所属团队的知识库、文件和成员

#### 路由权限分配

| 路由               | 页面         | admin | team_owner |
| ------------------ | ------------ | :---: | :--------: |
| `/dashboard`     | 用户管理     |  ✅  |     ❌     |
| `/team`          | 团队管理     |  ✅  |     ✅     |
| `/config`        | 用户配置     |  ✅  |     ❌     |
| `/file`          | 文件管理     |  ✅  |     ✅     |
| `/knowledgebase` | 知识库管理   |  ✅  |     ✅     |
| `/conversation`  | 用户会话管理 |  ✅  |     ❌     |

#### 登录管理

- **超级管理员**: 通过环境变量 `MANAGEMENT_ADMIN_USERNAME` 和 `MANAGEMENT_ADMIN_PASSWORD` 验证
- **团队负责人**: 通过数据库验证，检查 `user_tenant` 表中 `role = 'owner'` 的记录
- **普通用户**: 无权登录后台管理系统



